### PR TITLE
Better interactions with vanilla toggles

### DIFF
--- a/KKS_ClothingStateMenu/KKS_ClothingStateMenu.csproj
+++ b/KKS_ClothingStateMenu/KKS_ClothingStateMenu.csproj
@@ -132,6 +132,10 @@
       <HintPath>..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule.2019.4.9\lib\net46\UnityEngine.PhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.UI.2019.4.9\lib\net46\UnityEngine.UI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ClothingStateMenuPlugin.cs" />
@@ -161,6 +165,7 @@
     <Error Condition="!Exists('..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule.targets'))" />
     <Error Condition="!Exists('..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule.targets'))" />
     <Error Condition="!Exists('..\packages\IllusionLibs.KoikatsuSunshine.Unity.TextMeshPro.2019.4.9\build\IllusionLibs.KoikatsuSunshine.Unity.TextMeshPro.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.KoikatsuSunshine.Unity.TextMeshPro.2019.4.9\build\IllusionLibs.KoikatsuSunshine.Unity.TextMeshPro.targets'))" />
+    <Error Condition="!Exists('..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.UI.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.UI.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.UI.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.UI.targets'))" />
   </Target>
   <Import Project="..\packages\IllusionLibs.BepInEx.MonoMod.21.8.5.1\build\IllusionLibs.BepInEx.MonoMod.targets" Condition="Exists('..\packages\IllusionLibs.BepInEx.MonoMod.21.8.5.1\build\IllusionLibs.BepInEx.MonoMod.targets')" />
   <Import Project="..\packages\IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass.2021.9.17\build\IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass.targets" Condition="Exists('..\packages\IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass.2021.9.17\build\IllusionLibs.KoikatsuSunshine.Assembly-CSharp-firstpass.targets')" />
@@ -173,4 +178,5 @@
   <Import Project="..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule.targets" Condition="Exists('..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule.targets')" />
   <Import Project="..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule.targets" Condition="Exists('..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule.targets')" />
   <Import Project="..\packages\IllusionLibs.KoikatsuSunshine.Unity.TextMeshPro.2019.4.9\build\IllusionLibs.KoikatsuSunshine.Unity.TextMeshPro.targets" Condition="Exists('..\packages\IllusionLibs.KoikatsuSunshine.Unity.TextMeshPro.2019.4.9\build\IllusionLibs.KoikatsuSunshine.Unity.TextMeshPro.targets')" />
+  <Import Project="..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.UI.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.UI.targets" Condition="Exists('..\packages\IllusionLibs.KoikatsuSunshine.UnityEngine.UI.2019.4.9\build\IllusionLibs.KoikatsuSunshine.UnityEngine.UI.targets')" />
 </Project>

--- a/KKS_ClothingStateMenu/packages.config
+++ b/KKS_ClothingStateMenu/packages.config
@@ -14,5 +14,6 @@
   <package id="IllusionLibs.KoikatsuSunshine.UnityEngine.IMGUIModule" version="2019.4.9" targetFramework="net46" />
   <package id="IllusionLibs.KoikatsuSunshine.UnityEngine.InputLegacyModule" version="2019.4.9" targetFramework="net46" />
   <package id="IllusionLibs.KoikatsuSunshine.UnityEngine.PhysicsModule" version="2019.4.9" targetFramework="net46" />
+  <package id="IllusionLibs.KoikatsuSunshine.UnityEngine.UI" version="2019.4.9" targetFramework="net46" />
   <package id="IllusionModdingAPI.KKSAPI" version="1.27.0" targetFramework="net46" developmentDependency="true" />
 </packages>

--- a/Shared/ClothingStateMenuPlugin.cs
+++ b/Shared/ClothingStateMenuPlugin.cs
@@ -27,13 +27,18 @@ namespace ClothingStateMenu
 
         private ChaControl _chaCtrl;
         private SidebarToggle _sidebarToggle;
+        private List<bool> showAccessoryMemory;
 
         private bool _showOutsideMaker;
         private ConfigEntry<bool> ShowInMaker { get; set; }
 
 #if KK || KKS
         private ConfigEntry<bool> ShowCoordinateButtons { get; set; }
+        private ConfigEntry<bool> RetainStatesBetweenOutfits { get; set; }
+        private ConfigEntry<bool> ShowVanillaButtons { get; set; }
         private Action<int> _setCoordAction;
+
+        private int coordMemory = -1;
 #endif
 
         private ConfigEntry<KeyboardShortcut> Keybind { get; set; }
@@ -48,6 +53,11 @@ namespace ClothingStateMenu
             };
 
 #if KK || KKS
+            ShowVanillaButtons = Config.Bind("General", "Show Vanilla Acc Buttons", true, "Show the vanilla \"Main\" and \"Sub\" accessory toggle buttons. Disabling them can free up some space for other things in the sidebar.");
+            ShowVanillaButtons.SettingChanged += (sender, args) => ToggleAccButtons(ShowVanillaButtons.Value);
+            RetainStatesBetweenOutfits = Config.Bind("General", "Retain Acc States Between Outfits", false, "Acc slots toggled off in one outfit will remain toggled off in others.\nIf disabled, the accs sync up to the vanilla buttons on outfit change.");
+            MakerAPI.MakerFinishedLoading += (sender, e) => { RegisterToggleEvents(); ToggleAccButtons(ShowVanillaButtons.Value); };
+
             ShowCoordinateButtons = Config.Bind("General", "Show coordinate change buttons in Character Maker", false, "Adds buttons to the menu that allow quickly switching between clothing sets. Same as using the clothing dropdown.\nThe buttons are always shown outside of character maker.");
             ShowCoordinateButtons.SettingChanged += (sender, args) =>
             {
@@ -140,6 +150,28 @@ namespace ClothingStateMenu
         {
             if (Keybind.Value.IsDown())
                 ShowInterface = !ShowInterface;
+
+            if (MakerAPI.InsideMaker && _chaCtrl != null)
+            {
+                var showAccessory = _chaCtrl.fileStatus.showAccessory;
+                if (showAccessoryMemory != null && showAccessory.Length == showAccessoryMemory.Count)
+                {
+                    for (int i = 0; i < showAccessoryMemory.Count; i++)
+                    {
+                        if (showAccessory[i] != showAccessoryMemory[i] && _chaCtrl.nowCoordinate.accessory.parts[i].type != 120)
+                        {
+                            _chaCtrl.SetAccessoryState(i, showAccessoryMemory[i]);
+                        }
+                    }
+                }
+                showAccessoryMemory = showAccessory.ToList();
+
+#if KK || KKS
+                if (coordMemory != _chaCtrl.fileStatus.coordinateType && !RetainStatesBetweenOutfits.Value)
+                    showAccessoryMemory.Clear();
+                coordMemory = _chaCtrl.fileStatus.coordinateType;
+#endif
+            }
         }
 
         private void OnGUI()
@@ -155,24 +187,29 @@ namespace ClothingStateMenu
 
             GUILayout.BeginArea(_accesorySlotsRect);
             {
-                var showAccessory = _chaCtrl.fileStatus.showAccessory;
-                if (showAccessory.Length > 1)
+                if (showAccessoryMemory.Count > 1)
                 {
                     if (GUILayout.Button("All accs On"))
+                    {
                         _chaCtrl.SetAccessoryStateAll(true);
+                        showAccessoryMemory.Clear();
+                    }
                     GUILayout.Space(-5);
                     if (GUILayout.Button("All accs Off"))
+                    {
                         _chaCtrl.SetAccessoryStateAll(false);
+                        showAccessoryMemory.Clear();
+                    }
                 }
 
                 _accessorySlotsScrollPos = GUILayout.BeginScrollView(_accessorySlotsScrollPos);
                 {
                     GUILayout.BeginVertical();
                     {
-                        for (var j = 0; j < showAccessory.Length; j++)
+                        for (var j = 0; j < showAccessoryMemory.Count; j++)
                         {
                             if (_chaCtrl.nowCoordinate.accessory.parts[j].type != 120)
-                                DrawAccesoryButton(j, showAccessory[j]);
+                                DrawAccesoryButton(j, showAccessoryMemory[j]);
                         }
                     }
                     GUILayout.EndVertical();
@@ -201,7 +238,10 @@ namespace ClothingStateMenu
         private void DrawAccesoryButton(int accIndex, bool isOn)
         {
             if (GUILayout.Button($"Slot {accIndex + 1}: {(isOn ? "On" : "Off")}"))
+            {
                 _chaCtrl.SetAccessoryState(accIndex, !isOn);
+                showAccessoryMemory[accIndex] = !isOn;
+            }    
             GUILayout.Space(-5);
         }
 
@@ -249,5 +289,30 @@ namespace ClothingStateMenu
             }
 #endif
         }
+
+#if KK || KKS
+        private void ToggleAccButtons(bool _state)
+        {
+            Transform root = UnityEngine.Object.FindObjectsOfType<GameObject>().Where(x => x.name == "txtClothesState").FirstOrDefault().transform.parent;
+            for (int i = 0; i < root.childCount; i++)
+            {
+                if (root.GetChild(i).gameObject.name == "txtAccessory")
+                {
+                    root.GetChild(i + 0).gameObject.SetActive(_state);
+                    root.GetChild(i + 1).gameObject.SetActive(_state);
+                    root.GetChild(i + 2).gameObject.SetActive(_state);
+                    break;
+                }
+            }
+        }
+
+        private void RegisterToggleEvents()
+        {
+            UnityEngine.UI.Toggle toggle1 = UnityEngine.Object.FindObjectsOfType<GameObject>().Where(x => x.name == "imgTglCol01").FirstOrDefault().GetComponent<UnityEngine.UI.Toggle>();
+            UnityEngine.UI.Toggle toggle2 = UnityEngine.Object.FindObjectsOfType<GameObject>().Where(x => x.name == "imgTglCol02").FirstOrDefault().GetComponent<UnityEngine.UI.Toggle>();
+            toggle1.onValueChanged.AddListener((x) => { showAccessoryMemory.Clear(); });
+            toggle2.onValueChanged.AddListener((x) => { showAccessoryMemory.Clear(); });
+        }
+#endif
     }
 }

--- a/Shared/ClothingStateMenuPlugin.cs
+++ b/Shared/ClothingStateMenuPlugin.cs
@@ -13,7 +13,7 @@ namespace ClothingStateMenu
 {
     public partial class ClothingStateMenuPlugin : BaseUnityPlugin
     {
-        public const string Version = "3.1";
+        public const string Version = "3.2";
         public const string GUID = "ClothingStateMenu";
 
         private const float Height = 20f;


### PR DESCRIPTION
- Accessories now only sync up to the vanilla buttons when the buttons themselves are toggled
- Can hide vanilla buttons from F1 menu
- Can choose to retain toggle states when changing outfits, also in F1 menu
- New options default to unchanged behaviour